### PR TITLE
Permit PHPUnit command execution to be configurable

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -34,6 +34,9 @@ export WPT_TABLE_PREFIX=${WPT_TABLE_PREFIX-wptests_}
 # (Optionally) define the PHP executable to be called
 export WPT_PHP_EXECUTABLE=${WPT_PHP_EXECUTABLE-php}
 
+# (Optionally) define the PHPUnit command execution call.
+# Use if `php phpunit.phar` can't be called directly for some reason.
+
 # SSH connection string (can also be an alias).
 # Leave empty if tests are meant to run in the same environment.
 export WPT_SSH_CONNECT=

--- a/test.php
+++ b/test.php
@@ -13,12 +13,12 @@ $WPT_SSH_CONNECT = getenv( 'WPT_SSH_CONNECT' );
 $WPT_TEST_DIR = getenv( 'WPT_TEST_DIR' );
 $WPT_SSH_OPTIONS = getenv( 'WPT_SSH_OPTIONS' ) ? : '-o StrictHostKeyChecking=no';
 $WPT_PHP_EXECUTABLE = getenv( 'WPT_PHP_EXECUTABLE' ) ? : 'php';
+$WPT_PHPUNIT_CMD = getenv( 'WPT_PHPUNIT_CMD' ) ? : 'cd ' . escapeshellarg( $WPT_TEST_DIR ) . '; ' . $WPT_PHP_EXECUTABLE . ' phpunit.phar';
 
 // Run phpunit in the test environment
-$phpunit_exec = 'cd ' . escapeshellarg( $WPT_TEST_DIR ) . '; ' . $WPT_PHP_EXECUTABLE . ' phpunit.phar';
 if ( false !== $WPT_SSH_CONNECT ) {
-	$phpunit_exec = 'ssh ' . $WPT_SSH_OPTIONS . ' ' . escapeshellarg( $WPT_SSH_CONNECT ) . ' ' . escapeshellarg( $phpunit_exec );
+	$WPT_PHPUNIT_CMD = 'ssh ' . $WPT_SSH_OPTIONS . ' ' . escapeshellarg( $WPT_SSH_CONNECT ) . ' ' . escapeshellarg( $WPT_PHPUNIT_CMD );
 }
 perform_operations( array(
-	$phpunit_exec,
+	$WPT_PHPUNIT_CMD,
 ) );


### PR DESCRIPTION
Pantheon doesn't permit calling `ssh [...] php phpunit.phar` directly,
so the command execution needs to be proxied through a WP-CLI command.